### PR TITLE
Add "mark unwatched" button

### DIFF
--- a/src/assets/js/plex/PlexServer.js
+++ b/src/assets/js/plex/PlexServer.js
@@ -157,6 +157,13 @@ module.exports = function PlexServer () {
       return handleMetadata(result, that, callback)
     })
   }
+  this.markWatchedByRatingKey = function (ratingKey, callback) {
+    console.log('Marking ' + ratingKey + ' as watched')
+    this.hitApi('/:/scrobble', {
+      identifier: 'com.plexapp.plugins.library',
+      key: ratingKey
+    }, callback)
+  }
   this.getUrlForLibraryLoc = function (location, width, height, blur) {
     if (!(blur > 0)) {
       blur = 0

--- a/src/components/application/plexbrowser.vue
+++ b/src/components/application/plexbrowser.vue
@@ -161,15 +161,7 @@
     },
     name: 'plexbrowser',
     mounted () {
-
-      if (this.lastServer){
-        this.lastServer.getOnDeck(0, 10, (result) => {
-          if (result) {
-            this.onDeck = result
-          }
-        })
-      }
-
+      this.updateOnDeck()
     },
     methods: {
       setContent (content) {
@@ -183,7 +175,16 @@
           return true
         } 
         return false
-      },      
+      },
+      updateOnDeck () {
+        if (this.lastServer){
+          this.lastServer.getOnDeck(0, 10, (result) => {
+            if (result) {
+              this.onDeck = result
+            }
+          })
+        }
+      },
       subsetOnDeck (size) {
         if (!this.onDeck || !this.onDeck.MediaContainer || !this.onDeck.MediaContainer.Metadata){
             return []
@@ -191,6 +192,7 @@
         return this.onDeck.MediaContainer.Metadata.slice(this.onDeckOffset, this.onDeckOffset + size)
       },
       reset () {
+        this.updateOnDeck()
         this.browsingServer = false
         this.selectedItem = false
         this.results = []

--- a/src/components/application/plexbrowser/plexcontent.vue
+++ b/src/components/application/plexbrowser/plexcontent.vue
@@ -115,6 +115,9 @@
                 <v-card-actions class="pa-4" >
                   <v-spacer></v-spacer>
                   <div v-if="playable">
+                    <v-btn v-on:click.native="markWatched(content)">
+                      Mark Watched
+                    </v-btn>
                     <v-btn v-if="playable && content.Media.length == 1 && (content.viewOffset == 0 || !content.viewOffset)"  v-on:click.native="playMedia(content)" class="primary white--text">
                       <v-icon>play_arrow</v-icon> Play
                     </v-btn>                                 
@@ -334,6 +337,12 @@
         }
         return this.parentData.MediaContainer.Metadata.slice(this.contents.index - 1,this.contents.index + size -1)
       },
+      markWatched (content, mediaIndex) {
+        var that = this;
+        this.server.markWatchedByRatingKey(content.ratingKey, function () {
+          that.$parent.reset()
+        })
+      },
       playMedia (content, mediaIndex) {
         var callback = function(result){
           console.log(result)
@@ -351,9 +360,6 @@
             callback: callback
           }
         )
-        
-
-
       },
       getDuration (dur){
         return humanizeDuration(dur, { 

--- a/src/components/application/plexbrowser/plexserver.vue
+++ b/src/components/application/plexbrowser/plexserver.vue
@@ -118,12 +118,7 @@
           this.setBackground()
         }
       })
-      this.server.getOnDeck(0, 10, (result) => {
-        if (result) {
-          this.onDeck = result
-        }
-      })
-
+      this.updateOnDeck()
     },
     beforeDestroy () {
 
@@ -171,7 +166,14 @@
       },
       setLibrary (library) {
         this.browsingLibrary = library
-      },   
+      },
+      updateOnDeck() {
+        this.server.getOnDeck(0, 10, (result) => {
+          if (result) {
+            this.onDeck = result
+          }
+        })
+      },
       onDeckDown (){        
         if (!this.onDeck || !this.onDeck.MediaContainer || !this.onDeck.MediaContainer.Metadata){
             return false
@@ -268,6 +270,7 @@
         return this.server.getUrlForLibraryLoc(object.grandparentThumb, w / 3, h / 4)
       },
       reset () {
+        this.updateOnDeck()
         this.browsingLibrary = false
         this.selectedItem = false
         this.setBackground()


### PR DESCRIPTION
Any feedback would be welcome, I'm not familiar with the framework and codebase.

The first commit keeps the on-deck information up-to-date when browsing around, which is useful because items can easily be added or removed from it when something is watched or marked (un)watched on another player.

The second commit adds a "Mark Unwatched" button, that I find very helpful for videos that have been partially watched that I don't intend to finish, to easily remove them from the deck. The first commit ensures that videos that have just been marked as watched disappear from the deck when returning to it.